### PR TITLE
Add a configuration setting for the path to the love binary on Unix

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,11 @@
             "default": "C:\\Program Files\\LOVE\\love.exe",
             "description": "Love2d exe file path in Windows"
           },
+          "Unix Love2d Path": {
+            "type": "string",
+            "default": "love",
+            "description": "Love2d exe file path in Unix"
+          },
           "Save active file": {
             "type": "boolean",
             "default": false,

--- a/src/cmds/Love2d.ts
+++ b/src/cmds/Love2d.ts
@@ -50,6 +50,7 @@ const disposableLove2d = commands.registerCommand("loveme.love2d", () => {
 
   let love2dConfig = workspace.getConfiguration();
   let windowsLove2dPath: string|undefined = love2dConfig.get('Windows Love2d Path');
+  let unixLove2dPath: string|undefined = love2dConfig.get('Unix Love2d Path');
   // console.warn('get windows love 2d path:' + windowsLove2dPath);
   
   // let projectRoot = workspace.rootPath; // @deprecated
@@ -66,7 +67,7 @@ const disposableLove2d = commands.registerCommand("loveme.love2d", () => {
     window.showInformationMessage('Running love2d game ... ');
     // check love2d ...
     let isWindows = process.platform === 'win32';
-    let love2dExePath = isWindows ? `"${windowsLove2dPath}"` : 'love';
+    let love2dExePath = isWindows ? `"${windowsLove2dPath}"` : `"${unixLove2dPath}"`;
     // let love2dExePath = isWindows ? '"C:\\Program Files\\LOVE\\love.exe"' : 'love';
     child.exec(`${love2dExePath} --version`, function(error, stdout: string, stderr: string){
       if (error) {


### PR DESCRIPTION
This setting allows you to specify the path on Mac and Linux. Without this I was getting an error that it could not find the binary, even when `love` was in my `PATH` in `~/.zshrc`.