### PR TITLE
Move the startup message to the statusbar

### DIFF
--- a/src/cmds/Love2d.ts
+++ b/src/cmds/Love2d.ts
@@ -63,7 +63,10 @@ const disposableLove2d = commands.registerCommand("loveme.love2d", () => {
       return window.showErrorMessage(nomainlua);
     }
     
-    window.showInformationMessage('Running love2d game ... ');
+    // let the user know we are starting love2d
+    let statusBarMessage = 'Running love2d game...';
+    window.setStatusBarMessage(statusBarMessage);
+
     // check love2d ...
     let isWindows = process.platform === 'win32';
     let love2dExePath = isWindows ? `"${windowsLove2dPath}"` : 'love';
@@ -76,12 +79,19 @@ const disposableLove2d = commands.registerCommand("loveme.love2d", () => {
       }
       // LOVE 11.3 (Mysterious Mysteries) 
       console.log(stdout);
-      window.showInformationMessage(stdout);
+
+      // update the status bar with the love2d version information from stdout
+      window.setStatusBarMessage(`${statusBarMessage} ${stdout}`);
+
       // execute main.lua
-      child.exec(`${love2dExePath} ` + projectRoot);
+      child.exec(`${love2dExePath} ` + projectRoot).on("close", function(code: number, signal: NodeJS.Signals) {
+        // clear the status bar when the game is closed
+        window.setStatusBarMessage('');
+      });
     }).on("close", function(code, signal){
       // console.log('>>> love process closed!')
       loveStarted = false;
+
     }).on("error", function(code:any, signal:any){
       console.error('>>> love process error: '+code+'/'+signal);
     }).on("exit", function(code, signal){


### PR DESCRIPTION
Currently there are two information windows that pop up every time you launch Love2D. Unfortunately they don't auto close and there is no timeout option for information windows in VS Code. This change moves the status message to the status bar instead for a less obtrusive user experience. The status bar message is cleared when Love2D exits
![status bar](https://user-images.githubusercontent.com/28652/176709168-1dd96892-5c00-4d3a-9e6a-f3b5a583c6e4.png)
.